### PR TITLE
Fix httpx pinning for starlette compatibility

### DIFF
--- a/backend_fast/requirements.txt
+++ b/backend_fast/requirements.txt
@@ -9,6 +9,6 @@ python-multipart>=0.0.5,<0.1.0
 python-jose[cryptography]>=3.3.0,<3.4.0
 alembic>=1.7.0,<1.8.0
 minio>=7.2.8,<8.0.0
-httpx
+httpx>=0.23.0,<0.24.0
 pytest
 loguru>=0.7.0


### PR DESCRIPTION
## Summary
- pin httpx dependency in `backend_fast/requirements.txt`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593a859b8083208933793b490c7957